### PR TITLE
Rename target to KNIP SDK

### DIFF
--- a/org.knime.knip.sdk/knip-sdk-full.target
+++ b/org.knime.knip.sdk/knip-sdk-full.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Contains all OSGi bundles required for developing KNIP Nodes" sequenceNumber="147">
+<?pde version="3.8"?><target name="KNIP SDK" sequenceNumber="147">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="scifio-bf-compat" version="1.11.0"/>


### PR DESCRIPTION
The previous name was very long, causing it to typically be cut off in
Eclipse. The phrase that was showing "Contains all OSGi bundles.." may
confuse users about which is the actual KNIP SDK.
