### PR TITLE
Update target file

### DIFF
--- a/org.knime.knip.sdk/knip-sdk-full.target
+++ b/org.knime.knip.sdk/knip-sdk-full.target
@@ -2,45 +2,6 @@
 <?pde version="3.8"?><target name="Contains all OSGi bundles required for developing KNIP Nodes" sequenceNumber="148">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="scifio-bf-compat" version="1.11.0"/>
-<unit id="miglayout" version="3.7.4"/>
-<unit id="scifio-lifesci" version="0.7.0"/>
-<unit id="scijava-ui-awt" version="0.1.3"/>
-<unit id="imagej-ops" version="0.9.0"/>
-<unit id="imagej-common" version="0.12.1"/>
-<unit id="scijava-ui-swing" version="0.4.0"/>
-<unit id="imglib2-roi" version="0.2.1"/>
-<unit id="args4j" version="2.0.29"/>
-<unit id="trove4j" version="3.0.3"/>
-<unit id="scripting-java" version="0.2.5"/>
-<unit id="imagej-ui-swing" version="0.10.0"/>
-<unit id="imglib2-ij" version="2.0.29"/>
-<unit id="miglayout-swing" version="4.2.0"/>
-<unit id="jep" version="2.4.2"/>
-<unit id="knip-trackmate-fork" version="2.7.1"/>
-<unit id="imglib2-algorithm" version="0.2.0"/>
-<unit id="imagej-ui-awt" version="0.3.0"/>
-<unit id="slf4j-log4j12" version="1.7.10"/>
-<unit id="scijava-plugins-text-plain" version="0.1.1"/>
-<unit id="scijava-plugins-commands" version="0.1.8"/>
-<unit id="commons-collections" version="3.2.1"/>
-<unit id="imglib2" version="2.2.0"/>
-<unit id="imglib2-algorithm-fft" version="0.1.1"/>
-<unit id="scifio" version="0.21.0"/>
-<unit id="imagej-plugins-commands" version="0.4.1"/>
-<unit id="slf4j-api" version="1.7.10"/>
-<unit id="knip-tmp-imglib2-ops" version="0.1.4"/>
-<unit id="ij" version="1.49.0"/>
-<unit id="scijava-common" version="2.38.0"/>
-<unit id="scijava-log-slf4j" version="1.0.2"/>
-<unit id="jama" version="1.0.3"/>
-<unit id="imglib2-realtransform" version="2.0.28"/>
-<unit id="scripting-jython" version="0.1.4"/>
-<unit id="scijava-plugins-text-markdown" version="0.1.1"/>
-<unit id="imglib2-algorithm-gpl" version="0.1.2"/>
-<repository location="https://community.knime.org/download/knip-externals-trunk"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.knime.features.base.feature.group" version="2.11.2.0046103"/>
 <unit id="org.knime.features.base.filehandling.feature.group" version="2.11.2.0046096"/>
 <unit id="org.knime.features.virtual.feature.group" version="2.11.0.0045346"/>
@@ -55,6 +16,45 @@
 <unit id="org.knime.features.wizard.feature.group" version="2.11.0.0045404"/>
 <unit id="org.knime.features.base.treeensembles.feature.group" version="2.11.1.0045686"/>
 <repository location="http://www.knime.org/update/2.11/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="scifio-lifesci" version="0.7.0"/>
+<unit id="scifio-bf-compat" version="1.11.0"/>
+<unit id="miglayout" version="3.7.4"/>
+<unit id="scijava-ui-awt" version="0.1.3"/>
+<unit id="imagej-ops" version="0.9.0"/>
+<unit id="imagej-ui-swing" version="0.11.0"/>
+<unit id="scijava-ui-swing" version="0.4.0"/>
+<unit id="imglib2-roi" version="0.2.1"/>
+<unit id="scripting-jython" version="0.2.0"/>
+<unit id="args4j" version="2.0.29"/>
+<unit id="scijava-common" version="2.38.2"/>
+<unit id="trove4j" version="3.0.3"/>
+<unit id="scripting-java" version="0.2.5"/>
+<unit id="imglib2-ij" version="2.0.29"/>
+<unit id="imagej-common" version="0.12.2"/>
+<unit id="miglayout-swing" version="4.2.0"/>
+<unit id="jep" version="2.4.2"/>
+<unit id="knip-trackmate-fork" version="2.7.1"/>
+<unit id="imglib2-algorithm" version="0.2.0"/>
+<unit id="slf4j-log4j12" version="1.7.10"/>
+<unit id="imagej-ui-awt" version="0.3.0"/>
+<unit id="scijava-plugins-text-plain" version="0.1.1"/>
+<unit id="scijava-plugins-commands" version="0.1.8"/>
+<unit id="commons-collections" version="3.2.1"/>
+<unit id="imglib2" version="2.2.0"/>
+<unit id="imglib2-algorithm-fft" version="0.1.1"/>
+<unit id="imagej-plugins-commands" version="0.4.1"/>
+<unit id="slf4j-api" version="1.7.10"/>
+<unit id="knip-tmp-imglib2-ops" version="0.1.4"/>
+<unit id="ij" version="1.49.0"/>
+<unit id="scijava-log-slf4j" version="1.0.2"/>
+<unit id="jama" version="1.0.3"/>
+<unit id="imglib2-realtransform" version="2.0.28"/>
+<unit id="scijava-plugins-text-markdown" version="0.1.1"/>
+<unit id="scifio" version="0.21.1"/>
+<unit id="imglib2-algorithm-gpl" version="0.1.2"/>
+<repository location="https://community.knime.org/download/knip-externals-trunk"/>
 </location>
 </locations>
 </target>

--- a/org.knime.knip.sdk/knip-sdk-full.target
+++ b/org.knime.knip.sdk/knip-sdk-full.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Contains all OSGi bundles required for developing KNIP Nodes" sequenceNumber="147">
+<?pde version="3.8"?><target name="Contains all OSGi bundles required for developing KNIP Nodes" sequenceNumber="148">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="scifio-bf-compat" version="1.11.0"/>


### PR DESCRIPTION
When opening the old .target file in Eclipse, get a "Unable to locate installable unit..." error for components e.g. scifio-bf-compat, imagej-common, etc.

Re-importing KNIP OSGi update site generates a .target file with this location ordering and updated sequenceNumber, which resolves the errors.
