### PR TITLE
Remove treeensembles and fix version of optimization feature

### DIFF
--- a/org.knime.knip.sdk/nightly/knip-sdk-dev.target
+++ b/org.knime.knip.sdk/nightly/knip-sdk-dev.target
@@ -8,12 +8,11 @@
       <unit id="com.knime.features.enterprise.client.exampleserver.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.base.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.base.filehandling.feature.group" version="0.0.0"/>
-      <unit id="org.knime.features.base.treeensembles.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.core.streaming.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.distmatrix.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.ensembles.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.ext.jep.feature.group" version="0.0.0"/>
-      <unit id="org.knime.features.optimization.feature.group" version="3.0.0.0048491"/>
+      <unit id="org.knime.features.optimization.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.python.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.quickform.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.r.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Hi everybody! Hi @dietzc !

I had problems with these two bundles on the nightly target platform. Is it safe to remove the `org.knime.features.base.treeensembles.feature.group`?

There is a compilation error in "org.knime.knip.core.KNIPGuavaCacheService". Does that relate to that plugin beeing removed in any way?

Greetings,
Squareys
