### PR TITLE
Fix 3.7 target platform and launch configuration

### DIFF
--- a/org.knime.knip.sdk/knime-launch-configuration.launch
+++ b/org.knime.knip.sdk/knime-launch-configuration.launch
@@ -15,7 +15,6 @@
 <stringAttribute key="location" value="${workspace_loc}/../runtime-KNIP"/>
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
 <mapEntry key="J2D_D3D" value="false"/>
-<mapEntry key="SWT_GTK3" value="0"/>
 </mapAttribute>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
 <listAttribute key="org.eclipse.jdt.launching.CLASSPATH">

--- a/org.knime.knip.sdk/stable/knip-sdk-full-3.7.target
+++ b/org.knime.knip.sdk/stable/knip-sdk-full-3.7.target
@@ -17,7 +17,6 @@
       <unit id="org.knime.features.testingapplication.feature.group" version="0.0.0"/>
       <unit id="com.knime.features.enterprise.client.feature.group" version="0.0.0"/>
       <unit id="com.knime.features.enterprise.client.exampleserver.feature.group" version="0.0.0"/>
-      <unit id="com.knime.features.enterprise.server.ws.client.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.ext.osm.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.stats2.feature.group" version="0.0.0"/>
       <unit id="org.knime.features.ext.spotfire.feature.group" version="0.0.0"/>


### PR DESCRIPTION
* Remove old server feature from 3.7 target platform

  The feature com.knime.features.enterprise.server.ws.client is not
available on the update site.

* Remove SWT_GTK3=0 env variable from launch config

  KNIME runs fine with GTK3 for some time now.